### PR TITLE
Google Closure Compiler upgrade: Removing duplicate object keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+html-report
+sauce_connect.log
+coverage-final.json
+npm-debug.log

--- a/MultiLinearScaler.js
+++ b/MultiLinearScaler.js
@@ -26,7 +26,6 @@ define(["dojo/_base/declare", "dojo/Stateful"], function(declare, Stateful){
 		//		The array of generated minor ticks. You should not set this
 		//		property when using the scaler.
 		minorTicks: null,
-		_snapIntervalPrecision: null,
 		_snapCount: 4,
 		_snapIntervalPrecision: 6,
 		


### PR DESCRIPTION
Dojo 1.x uses currently the Google Closure Compiler v20160911.

It is currently impossible to upgrade the Google Closure Compiler to a newer version. The reason is — there is an incompatibility issue, when using the Google Closure Compiler to process Dojo applications: duplicate object keys.

This pull request introduces changes to the Dojo Gauges 1.x's source code that remove all the occurrences of duplicate object keys in code.